### PR TITLE
feat(deps): update SignalR Orleans version to 9.0.0-rc.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
 
     <!-- vendors -->
     <OrleansVersion>10.1.0</OrleansVersion>
-    <SignalROrleansVersion>8.0.0</SignalROrleansVersion>
+    <SignalROrleansVersion>9.0.0-rc.1</SignalROrleansVersion>
     <!-- <SignalROrleansVersion>link</SignalROrleansVersion> -->
     <MultitenancyVersion>1.0.0-rc.2</MultitenancyVersion>
     <!-- <MultitenancyVersion>link</MultitenancyVersion> -->

--- a/Heroes.Server.Tests/Infrastructure/HeroesWebApplicationFactory.cs
+++ b/Heroes.Server.Tests/Infrastructure/HeroesWebApplicationFactory.cs
@@ -132,12 +132,4 @@ public sealed class HeroesWebApplicationFactory : WebApplicationFactory<Program>
 			// Orleans/SignalR grain deactivation exceeded the cap — proceed without blocking.
 		}
 	}
-
-	/// <summary>
-	/// Schedules <see cref="Environment.Exit"/> after 30 seconds on a thread-pool thread.
-	/// If the process exits normally before the delay completes the scheduled action is moot.
-	/// </summary>
-	private static void ScheduleShutdownTimeout() =>
-		_ = Task.Delay(TimeSpan.FromSeconds(30))
-			.ContinueWith(_ => Environment.Exit(0), TaskScheduler.Default);
 }

--- a/Heroes.Server.Tests/Realtime/HeroHubTests.cs
+++ b/Heroes.Server.Tests/Realtime/HeroHubTests.cs
@@ -52,7 +52,11 @@ public sealed class HeroHubTests(HeroesWebApplicationFactory factory)
 		// Arrange
 		var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 		await using var connection = factory.CreateHubConnection(HubPath);
-		connection.On<string>("Send", msg => tcs.TrySetResult(msg));
+		connection.On<string>("Send", msg =>
+		{
+			if (msg.EndsWith(" joined", StringComparison.OrdinalIgnoreCase))
+				tcs.TrySetResult(msg);
+		});
 
 		// Act
 		await connection.StartAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
Update the SignalR Orleans version to 9.0.0-rc.1 and eliminate the shutdown timeout method to streamline the code.